### PR TITLE
changes for new blast format

### DIFF
--- a/brocclib/get_xml.py
+++ b/brocclib/get_xml.py
@@ -117,14 +117,14 @@ def get_lineage(taxid):
                 num_tries += 1
         except urllib2.URLError as e:
             num_tries += 1
-            print e
-            print "Database connectiom timed out for taxon", taxid, "Will retry"
+            print(e)
+            print("Database connectiom timed out for taxon", taxid, "Will retry")
         except Exception as e:
             num_tries += 1
-            print e, "Will retry"
+            print(e, "Will retry")
     if num_tries == 5:
-        print "could not connect to db for taxon" + str(taxid)
-        print str(taxid) + " will not be considered"
+        print("could not connect to db for taxon" + str(taxid))
+        print(str(taxid) + " will not be considered")
         return None
 
 

--- a/brocclib/parse.py
+++ b/brocclib/parse.py
@@ -48,7 +48,7 @@ def iter_blast(blast_lines):
                 query_id = full_query_id
             # Need to extract the GI number from the NCBI formatted
             # reference ID.
-            gi_num = parse_gi_number(vals[1])
+            gi_num = parse_accession(vals[1]) #parse_gi_number(vals[1])
             pct_id = float(vals[2])
             length = float(vals[3])
             hit = BlastHit(gi_num, pct_id, length)
@@ -71,3 +71,10 @@ def parse_gi_number(id_string):
                 return t2
         return None
 
+def parse_accession(desc):
+    if "|" in desc:
+        # old blast format
+        return desc.split("|")[3]
+    else:
+        # new blast format
+        return desc

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,7 +2,7 @@ from unittest import TestCase, main
 from cStringIO import StringIO
 
 from brocclib.parse import (
-    read_blast, iter_fasta, parse_gi_number,
+    read_blast, iter_fasta, parse_gi_number, parse_accession
     )
 
 
@@ -14,6 +14,10 @@ class GiNumberTests(TestCase):
     def test_gi_empty(self):
         for s in ['', 'gi', 'ran|dom']:
             self.assertEqual(parse_gi_number(s), None)
+    
+    def test_accession(self):
+        obs = parse_accession("KP131807.1")
+        self.assertEqual(obs, "KP131807.1")
 
 
 class FastaTests(TestCase):


### PR DESCRIPTION
In the new blast format, no gi number but accession number instead. 
simple fix